### PR TITLE
Several Yealink package updates

### DIFF
--- a/endpoint/yealink/brand_data.xml
+++ b/endpoint/yealink/brand_data.xml
@@ -5,28 +5,28 @@
 		<version>0.5</version>
 		<brand_id>8</brand_id>
 		<directory>yealink</directory>
-		<package>yealink-0_5.tgz</package>
-        <md5sum>60ccc350d1e098caa640977ecb475230</md5sum>
-		<last_modified>1311145473</last_modified>
+		<package>yealink-0_7.tgz</package>
+        <md5sum>8d9ed1b3d0352ae1b4675971e1e2c5d7</md5sum>
+		<last_modified>1311660781</last_modified>
 		<family_list>
 <!--Below is Auto Generated-->
 			<family>
-				<name>Yealink/Dreamwave Models: [T20, T22, T26, T28]</name>
+				<name>Yealink/Dreamwave T2X Models: [T20, T22, T26, T28]</name>
 				<directory>t2x</directory>
-				<version>0.7.5</version>
-				<description>Variables Issues Solved (Not writing accounts + passwords in files)</description>
-				<changelog>PACKAGER: Preliminary support for the Yealink T38G and (completely untested for obvious reasons) the upcoming T32G.</changelog>
+				<version>0.7.7</version>
+				<description>Make more settings availble in the user interface</description>
+				<changelog></changelog>
 				<id>1</id>
-				<last_modified>1307829216</last_modified>
+				<last_modified>1311660781</last_modified>
 			</family>
 			<family>
 				<name>Yealink/Dreamwave T3X Models: [T32, T38]</name>
 				<directory>t3x</directory>
-				<version>0.0.1</version>
-				<description>Configuration for the Yealink T3X series of phones)</description>
+				<version>0.0.2</version>
+				<description>Make more settings availble in the user interface</description>
 				<changelog></changelog>
 				<id>2</id>
-				<last_modified>1311145473</last_modified>
+				<last_modified>1311660781</last_modified>
 			</family>
 <!--End Auto Generated-->
 

--- a/endpoint/yealink/t2x/$mac.cfg
+++ b/endpoint/yealink/t2x/$mac.cfg
@@ -234,6 +234,14 @@ Value = {$extension}
 {/loop_linekey}
 #END Line Key Options
 
+#START DialNow configuration
+[ DialNow ]
+path = /tmp/dialnow.xml
+{loop_dialnow}
+${count} = ${rule}
+{/loop_dialnow}
+#END DialNow configuration
+
 {loop_sdext38}
 [ Key{$number} ]
 Path = /config/vpPhone/Ext38_00000000000001.cfg
@@ -310,3 +318,7 @@ DKtype = {$hardkey_fwd_type}
 Line = {$hardkey_fwd_line}
 Value = {$hardkey_fwd_value}
 XMLPhoneBook =
+
+[ AdminPassword ]
+path = /config/Setting/autop.cfg
+Password = ${adminpw}

--- a/endpoint/yealink/t2x/family_data.xml
+++ b/endpoint/yealink/t2x/family_data.xml
@@ -1,12 +1,12 @@
 <data>
-	<name>Yealink/Dreamwave Models: [T20, T22, T26, T28]</name>
+	<name>Yealink/Dreamwave T2X Models: [T20, T22, T26, T28]</name>
 	<id>1</id>
-	<version>0.7.5</version>
+	<version>0.7.7</version>
 	<directory>t2x</directory>
 	<firmware_ver></firmware_ver>
 	<firmware_pkg>NULL</firmware_pkg>
     <firmware_md5sum></firmware_md5sum>
-	<description>Variables Issues Solved (Not writing accounts + passwords in files)</description>
+	<description>Make more configuration settings available from UI</description>
 	<configuration_files>y000000000000.cfg,$mac.cfg</configuration_files>
 	<changelog></changelog>
 	<model_list>
@@ -17,12 +17,13 @@
             <files>line_options_22.xml</files>
 			<files>template_data.xml</files>
 			<files>memory_keys.xml</files>
+			<files>dialnow_22.xml</files>
 			<files>ext38.xml</files>
 		</template_data>
 	</model_list>
 	<model_list>
 		<model>T22</model>
-		<lines>2</lines>
+		<lines>3</lines>
 		<id>2</id>
 		<template_data>
 			<files>line_options_22.xml</files>
@@ -31,6 +32,7 @@
 			<files>line_keys_22.xml</files>
 			<files>soft_keys_22.xml</files>
 			<files>hard_keys_22.xml</files>
+			<files>dialnow_22.xml</files>
 			<files>ext38.xml</files>
 		</template_data>
 	</model_list>
@@ -46,21 +48,23 @@
 			<files>soft_keys_22.xml</files>
 			<files>hard_keys_22.xml</files>
 			<files>memory_keys_22.xml</files>
+			<files>dialnow_22.xml</files>
 			<files>ext38.xml</files>
 		</template_data>
 	</model_list>
 	<model_list>
 		<model>T28</model>
-		<lines>2</lines>
+		<lines>6</lines>
 		<id>4</id>
 		<template_data>
 			<files>line_options_22.xml</files>
 			<files>template_data.xml</files>
 			<files>network_22.xml</files>
-			<files>line_keys_22.xml</files>
+			<files>line_keys_28.xml</files>
 			<files>soft_keys_22.xml</files>
 			<files>hard_keys_22.xml</files>
 			<files>memory_keys_22.xml</files>
+			<files>dialnow_22.xml</files>
 			<files>ext38.xml</files>
 		</template_data>
 	</model_list>

--- a/endpoint/yealink/t2x/phone.php
+++ b/endpoint/yealink/t2x/phone.php
@@ -57,6 +57,14 @@ class endpoint_yealink_t2x_phone extends endpoint_yealink_base {
 					$this->options['linekey'][15]['pickup'] = $this->options['linekey'][$line]['pickup'];
 					unset($this->options['linekey'][$line]);
 					break;		
+				case "5":
+					$this->options['linekey'][16]['type'] = $this->options['linekey'][$line]['type'];
+					$this->options['linekey'][16]['mode'] = $this->options['linekey'][$line]['mode'];
+					$this->options['linekey'][16]['line'] = $this->options['linekey'][$line]['line'];
+					$this->options['linekey'][16]['extension'] = $this->options['linekey'][$line]['extension'];
+					$this->options['linekey'][16]['pickup'] = $this->options['linekey'][$line]['pickup'];
+					unset($this->options['linekey'][$line]);
+					break;		
 			}
 		}
 	}

--- a/endpoint/yealink/t2x/template_data.xml
+++ b/endpoint/yealink/t2x/template_data.xml
@@ -65,11 +65,79 @@
                 <type>input</type>
             </item>
             <item>
+                <type>break</type>
+            </item>
+            <item>
+            	<category>system</category>
+            	<variable>$update_mode</variable>
+            	<default_value>7</default_value>
+            	<description>Config Update Mode</description>
+            	<type>list</type>
+            	<data>
+            		<text>Disabled</text>
+            		<value>0</value>
+            		<disable>$update_frequency</disable>
+            	</data>
+            	<data>
+            		<text>Power on</text>
+            		<value>1</value>
+            		<disable>$update_frequency</disable>
+            	</data>
+            	<data>
+            		<text>Repeatedly</text>
+            		<value>4</value>
+            		<enable>$update_frequency</enable>
+            	</data>
+            	<data>
+            		<text>Weekly</text>
+            		<value>5</value>
+            		<disable>$update_frequency</disable>
+            	</data>
+            	<data>
+            		<text>Power on + Repeatedly</text>
+            		<value>6</value>
+            		<enable>$update_frequency</enable>
+            	</data>
+            	<data>
+            		<text>Power on + Weekly</text>
+            		<value>7</value>
+            		<disable>$update_frequency</disable>
+            	</data>
+            </item>
+            <item>
+            	<category>system</category>
+            	<variable>$update_frequency</variable>
+            	<description>Update Frequency (mins)</description>
+            	<default_value>1440</default_value>
+            	<type>input</type>
+            	<max_len>5</max_len>
+            </item>
+            <item>
+                <type>break</type>
+            </item>
+            <item>
                 <category>system</category>
                 <variable>$call_pickup</variable>
                 <default_value>**</default_value>
                 <description>Call Pickup Value (For BLF)</description>
                 <type>input</type>
+            </item>
+            <item>
+                <type>break</type>
+            </item>
+            <item>
+            	<category>system</category>
+            	<variable>$adminpw</variable>
+            	<default_value />
+            	<description>Web administration password</description>
+            	<type>input</type>
+            </item>
+            <item>
+            	<category>system</category>
+            	<variable>$tones_country</variable>
+            	<default_value>United States</default_value>
+            	<description>Tones Country</description>
+            	<type>input</type>
             </item>
         </subcategory>
     </category>

--- a/endpoint/yealink/t2x/y000000000000.cfg
+++ b/endpoint/yealink/t2x/y000000000000.cfg
@@ -17,18 +17,15 @@ path = /config/Setting/autop.cfg
 #schedule_dayofweek is the setting for weekly choosen, Sunday:0; Monday:1; Tuesday:2;...if you want to update every sunday and Saturday, you could set it to 06
 mode = {$update_mode}
 schedule_min = {$update_frequency}
-schedule_time =
-schedule_time_end =
-schedule_dayofweek =
-
+schedule_time = 23:00
+schedule_dayofweek = 0
 
 [ autoprovision ]
 path = /config/Setting/autop.cfg
-server_type = {$update_method}
-server_address = {$update_server}
-user = {$update_user}
-password = {$update_pass}
-
+server_type = tftp
+server_address = {$server.ip.1}
+user = 
+password = 
 
 [ AES_KEY ]
 path = /config/Setting/autop.cfg
@@ -102,7 +99,7 @@ firmware_name = {$firmware_name}
 path = /config/Setting/Setting.cfg
 TimeZone = {$timezone}
 TimeServer1= {$server.ip.1}
-TimeServer2 =
+TimeServer2 = pool.ntp.org
 TimeZoneName = United States-Pacific Time
 Interval = 43200
 #Set daylight saving time.SummerTime 0 means disable,1 means enable, 2 means automatic
@@ -139,7 +136,7 @@ Enable = 0
 [ Country ]
 path=/config/voip/tone.ini
 #The tones are defined by countries.If Country = Custom,the customized values will be used.
-Country = United States
+Country = ${tones_country}
 
 [ Default ]
 path=/config/voip/tone.ini
@@ -167,13 +164,14 @@ Lock = 0
 #the range of the volume is 1~15
 Voicevolume = 4
 Ringtype = Ring1.wav
-HandFreeSpkVol = 8
-HandFreeMicVol = 8
-HandSetSpkVol = 8
-HandSetMicVol = 8
-HeadSetSpkVol = 8
-HeadSetMicVol = 8
-RingVol= 3
+#HandFreeSpkVol = 8
+#HandFreeMicVol = 8
+#HandSetSpkVol = 8
+#HandSetMicVol = 8
+#HeadSetSpkVol = 8
+#HeadSetMicVol = 8
+#RingVol= 3
+DialNowDelay = ${dialnowdelay}
 
 [ Lang ]
 path = /config/Setting/Setting.cfg
@@ -306,11 +304,6 @@ Adaptive = 1
 Min = 0
 Max = 300
 Nominal = 120
-
-[ Country ]
-path = /config/voip/tone.ini
-#The tones are defined by countries.If Country = Custom,the customized values will be used.
-Country = United States
 
 [ Tone Param ]
 path = /config/voip/tone.ini

--- a/endpoint/yealink/t3x/$mac.cfg
+++ b/endpoint/yealink/t3x/$mac.cfg
@@ -28,7 +28,7 @@ account.BackupSIPServerHost = {$bk_sip_server}
 account.BackupSIPServerPort = {$bk_sip_server_port}
 account.Enable 100Rel = 0
 account.precondition = 0
-account.SubsribeRegister = 1
+account.SubscribeRegister = 1
 account.CIDSource = 0
 account.EnableSessionTimer = 0
 account.SessionExpires = 
@@ -36,7 +36,7 @@ account.SessionRefresher = 0
 account.EnableUserEqualPhone = 0
 account.BLFList_URI = 
 account.BlfListCode =
-account.SubsribeMWI = {$subscribe_mwi}
+account.SubscribeMWI = {$subscribe_mwi}
 account.AnonymousCall = 0
 account.RejectAnonymousCall = 0
 account.Transport = {$transport}
@@ -78,9 +78,11 @@ ADVANCED.default_t4 = 5
 blf.SubscribePeriod = 360
 {/line_loop}
 
-[ cfg:/phone/config/user.ini,reboot=1 ]
+[ cfg:/phone/config/system.ini,reboot=1 ]
 RemotePhoneBook0.URL = {$remote_phone_book_url}
 RemotePhoneBook0.Name = {$remote_phone_book_name}
+
+[ cfg:/phone/config/user.ini,reboot=1 ]
 PhoneSetting.BackGrounds = Config:IMG_3156.jpg
 
 [ bin:/phone/userdata/BackGround/IMG_3156.jpg ]
@@ -104,7 +106,17 @@ memory{$number}.Value = {$value}
 memory{$number}.PickupValue = {$pickup_value}
 {/loop_memkey}
 
-# Soft Keys
+[ cfg:/phone/config/vpPhone/Ext38_00000000000001.cfg ]
+{loop_sdext38}
+Key{$number}.Line = {$line}
+Key{$number}.type = {$mode}
+Key{$number}.DKtype = {$type}
+Key{$number}.Value = {$extension}
+Key{$number}.PickupValue = {$pickup_value}
+Key{$number}.Label = {$extension}
+{/loop_sdext38}
+
+[ cfg:/phone/config/vpPhone/vpPhone.ini ]
 {loop_softkey}
 programablekey{number}.DKtype = {$type}
 programablekey{number}.Line = {$line}
@@ -153,14 +165,4 @@ programablekey14.DKtype = {$hardkey_fwd_type}
 programablekey14.Line = {$hardkey_fwd_line}
 programablekey14.Value = {$hardkey_fwd_extension}
 programablekey14.XMLPhoneBook =
-
-[ cfg:/phone/config/vpPhone/Ext38_00000000000001.cfg ]
-{loop_sdext38}
-Key{$number}.Line = {$line}
-Key{$number}.type = {$mode}
-Key{$number}.DKtype = {$type}
-Key{$number}.Value = {$extension}
-Key{$number}.PickupValue = {$pickup_value}
-Key{$number}.Label = {$extension}
-{/loop_sdext38}
 

--- a/endpoint/yealink/t3x/family_data.xml
+++ b/endpoint/yealink/t3x/family_data.xml
@@ -1,13 +1,13 @@
-<data>
+﻿<data>	
 	<name>Yealink/Dreamwave T3X Models: [T32, T38]</name>
 	<id>2</id>
-	<version>0.0.1</version>
+	<version>0.0.2</version>
 	<directory>t3x</directory>
 	<firmware_ver></firmware_ver>
 	<firmware_pkg>NULL</firmware_pkg>
     <firmware_md5sum></firmware_md5sum>
-	<description>Configuration for the Yealink T3X series of phones)</description>
-	<configuration_files>y000000000000.cfg,$mac.cfg</configuration_files>
+	<description>Make more settings available in user interface</description>
+	<configuration_files>y000000000000.cfg,$mac.cfg,dialnow.xml</configuration_files>
 	<changelog></changelog>
 	<model_list>
 		<model>T32</model>
@@ -20,21 +20,23 @@
 			<files>line_keys_22.xml</files>
 			<files>soft_keys_22.xml</files>
 			<files>hard_keys_22.xml</files>
+			<files>dialnow_22.xml</files>
 			<files>ext38.xml</files>
-		</template_data>
+    </template_data>
 	</model_list>
 	<model_list>
 		<model>T38</model>
 		<lines>6</lines>
 		<id>2</id>
 		<template_data>
-                        <files>line_options_22.xml</files>
+      <files>line_options_22.xml</files>
 			<files>template_data.xml</files>
 			<files>network_22.xml</files>
 			<files>line_keys_28.xml</files>
 			<files>soft_keys_22.xml</files>
 			<files>hard_keys_22.xml</files>
 			<files>memory_keys_22.xml</files>
+			<files>dialnow_22.xml</files>
 			<files>ext38.xml</files>
 		</template_data>
 	</model_list>

--- a/endpoint/yealink/t3x/line_keys_28.xml
+++ b/endpoint/yealink/t3x/line_keys_28.xml
@@ -4,7 +4,7 @@
         <subcategory>
             <name>basic</name>
             <item>
-                <description>Line Keys (1-5)</description>
+                <description>Line Keys (1-6)</description>
                 <type>loop</type>
                 <loop_start>1</loop_start>
                 <loop_end>6</loop_end>

--- a/endpoint/yealink/t3x/phone.php
+++ b/endpoint/yealink/t3x/phone.php
@@ -5,7 +5,6 @@
  * @author Andrew Nagy
  * @license MPL / GPLv2 / LGPL
  * @package Provisioner
- * 
  */
 class endpoint_yealink_t3x_phone extends endpoint_yealink_base {
 
@@ -74,6 +73,14 @@ class endpoint_yealink_t3x_phone extends endpoint_yealink_base {
 					$this->options['linekey'][15]['pickup'] = $this->options['linekey'][$key]['pickup'];
 					unset($this->options['linekey'][$key]);
 					break;		
+					case "6":
+					$this->options['linekey'][16]['type'] = $this->options['linekey'][$key]['type'];
+					$this->options['linekey'][16]['mode'] = $this->options['linekey'][$key]['mode'];
+					$this->options['linekey'][16]['line'] = $this->options['linekey'][$key]['line'];
+					$this->options['linekey'][16]['extension'] = $this->options['linekey'][$key]['extension'];
+					$this->options['linekey'][16]['pickup'] = $this->options['linekey'][$key]['pickup'];
+					unset($this->options['linekey'][$key]);
+					break;		
 				}
 			}
 		}
@@ -121,9 +128,7 @@ class endpoint_yealink_t3x_phone extends endpoint_yealink_base {
                 }
             }
         }
-
-
-
+        
         //Yealink support lines 2-6, so let's add them if they're set
         for ($i = 1; $i < 6; $i++) {
             $this->lines[$i]['options']['line_active'] = (isset($this->lines[$i]['secret']) ? '1' : '0');
@@ -138,6 +143,13 @@ class endpoint_yealink_t3x_phone extends endpoint_yealink_base {
         $contents = $this->open_config_file("\$mac.cfg");
 
         $final[$this->mac.'.cfg'] = $this->parse_config_file($contents, FALSE);
+
+
+	//dialnow.xml file
+	$contents = $this->open_config_file("dialnow.xml");
+
+	$final['dialnow.xml'] = $this->parse_config_file($contents, FALSE);
+
 
         return($final);
     }

--- a/endpoint/yealink/t3x/template_data.xml
+++ b/endpoint/yealink/t3x/template_data.xml
@@ -52,17 +52,13 @@
             </item>
             <item>
                 <category>system</category>
-                <variable>$firmware_server</variable>
-                <default_value>{$server.ip.1}</default_value>
-                <description>Firmware Server IP</description>
+                <variable>$firmware_name</variable>
+                <default_value></default_value>
+                <description>Firmware URL</description>
                 <type>input</type>
             </item>
             <item>
-                <category>system</category>
-                <variable>$firmware_name</variable>
-                <default_value></default_value>
-                <description>Firmware File Name</description>
-                <type>input</type>
+                <type>break</type>
             </item>
             <item>
                 <category>system</category>
@@ -70,6 +66,23 @@
                 <default_value>**</default_value>
                 <description>Call Pickup Value (For BLF)</description>
                 <type>input</type>
+            </item>
+            <item>
+                <type>break</type>
+            </item>
+            <item>
+            	<category>system</category>
+            	<variable>$adminpw</variable>
+            	<default_value />
+            	<description>Web administration password</description>
+            	<type>input</type>
+            </item>
+            <item>
+            	<category>system</category>
+            	<variable>$tones_country</variable>
+            	<default_value>United States</default_value>
+            	<description>Tones Country</description>
+            	<type>input</type>
             </item>
         </subcategory>
     </category>

--- a/endpoint/yealink/t3x/y000000000000.cfg
+++ b/endpoint/yealink/t3x/y000000000000.cfg
@@ -39,6 +39,7 @@ vpm_tone_Country.Country = Australia
 
 PhoneSetting.BacklightTime = 120
 PhoneSetting.UnusedBackLight = 4
+PhoneSetting.DialNowDelay = ${dialnowdelay}
 
 AlertInfo0.Text = interal
 AlertInfo0.Ringer = 2
@@ -48,9 +49,12 @@ AlertInfo1.Ringer = 5
 
 Emergency.Num = 000
 
+[ bin:/phone/config/DialNow.xml,reboot=0 ]
+url=tftp://{$server.ip.1}/dialnow.xml
+
 [ psw:/phone/config/.htpasswd ]
-admin = h0b@rt
+admin = {$adminpw}
 
 [ rom:Firmware ]
-url = tftp://{$firmware_server}/{$firmware_name}
+url = {$firmware_name}
 


### PR DESCRIPTION
Several updates have been made to both the T2X and T3X families, including:-
- Support for DialNow
- Ability to specify how often the phone will check for configuration updates in the user interface (T2X only)
- Ability to set the phone's user interface password from the user interface + Ability to set the phone's dial tone country in the user interface
- Ability to set full firmware URL, rather than have TFTP forced on you (T3X only)
- Remove specific settings for handset/headset/speakerphone volume settings so user preferences don't get overridden every time the phone re-provisions
  ! Fix phone.php to allow all six lines to be configured on a T38 or T28.
  ! Fix a couple of typos in the default $mac.cfg for T3X series
