### PR TITLE
Support for Grandstream GXP1400/1405

### DIFF
--- a/endpoint/grandstream/gxp/family_data.json
+++ b/endpoint/grandstream/gxp/family_data.json
@@ -62,6 +62,22 @@
         "template_data": [
           "template_data.json"
         ]
+      },
+      {
+        "model": "GXP1400",
+        "lines": "2",
+        "id": "8",
+        "template_data": [
+          "template_data.json"
+        ]
+      },
+      {
+        "model": "GXP1405",
+        "lines": "2",
+        "id": "9",
+        "template_data": [
+          "template_data.json"
+        ]
       }
     ]
   }


### PR DESCRIPTION
Just added GXP1400/1405 (1405 supports PoE) to the Grandstream family_data.json.
