### PR TITLE
Update base.php

### DIFF
--- a/endpoint/base.php
+++ b/endpoint/base.php
@@ -872,9 +872,9 @@ class Provisioner_Globals {
                 </flat-profile>");
                 break;
             //yealink
-            case 'y000000000000.cfg':
-                return("#left blank");
-                break;
+            //case 'y000000000000.cfg':
+            //    return("#left blank");
+            //    break;
             //aastra
             case "aastra.cfg":
                 return("#left blank");


### PR DESCRIPTION
This breaks the ability to provision Yealink T28 phones as their common cfg file is y000000000000.cfg.
