### PR TITLE
Update template_data.json to correctly reference existing Australia/Victoria dialplan-vic.xml

### DIFF
--- a/endpoint/cisco/sip99xx/template_data.json
+++ b/endpoint/cisco/sip99xx/template_data.json
@@ -148,7 +148,7 @@
                   },
 		  {
                     "text":"VIC",
-                    "value":"dialplan-nsw.xml"
+                    "value":"dialplan-vic.xml"
                   },
                   {
                     "text":"PER/ADL",


### PR DESCRIPTION
I noticed that OSS EPM in FreePBX was providing the wrong dialplan.xml for Victoria. Without this change it's configuring TFTP files for Cisco phones to use dialplan-nsw.xml instead of dialplan-vic.xml
