### PR TITLE
Fix daylightSavings for Polycom spipm

### DIFF
--- a/endpoint/polycom/spipm/sip.cfg
+++ b/endpoint/polycom/spipm/sip.cfg
@@ -63,7 +63,18 @@
        tcpIpApp.sntp.address.overrideDHCP="{$sntp_overrideDHCP|1}"
        tcpIpApp.sntp.gmtOffset="{$timezone_gmtoffset}"
        tcpIpApp.sntp.gmtOffset.overrideDHCP="{$sntp_overrideDHCP|1}"
-       tcpIpApp.sntp.daylightSavings.enable="{$daylightSavings_enable|0}"/>
+       tcpIpApp.sntp.daylightSavings.enable="{$daylightSavings_enable|0}"
+       tcpIpApp.sntp.daylightSavings.fixedDayEnable="{$daylightSavings_fixedDayEnable|0}"
+       tcpIpApp.sntp.daylightSavings.start.month="{$daylightSavings_month|3}"
+       tcpIpApp.sntp.daylightSavings.start.date="{$daylightSavings_date|8}"
+       tcpIpApp.sntp.daylightSavings.start.time="{$daylightSavings_time|2}"
+       tcpIpApp.sntp.daylightSavings.start.dayOfWeek="{$daylightSavings_dayOfWeek|1}"
+       tcpIpApp.sntp.daylightSavings.start.dayOfWeek.lastInMonth="{$daylightSavings_lastInMonth|0}"
+       tcpIpApp.sntp.daylightSavings.stop.month="{$daylightSavings_month|11}"
+       tcpIpApp.sntp.daylightSavings.stop.date="{$daylightSavings_date|1}"
+       tcpIpApp.sntp.daylightSavings.stop.time="{$daylightSavings_time|2}"
+       tcpIpApp.sntp.daylightSavings.stop.dayOfWeek="{$daylightSavings_dayOfWeek|1}"
+       tcpIpApp.sntp.daylightSavings.stop.dayOfWeek.lastInMonth="{$daylightSavings_lastInMonth|0}"/>
   </TCP_IP>
   <logging>
      <level>


### PR DESCRIPTION
These settings were missing from spipm but were included with the legacy firmwares.
