### PR TITLE
DO NOT MERGE - Buddy Lists for Polycom 601 phones

### DIFF
--- a/endpoint/polycom/splm/buddylist.json
+++ b/endpoint/polycom/splm/buddylist.json
@@ -1,0 +1,98 @@
+{
+    "template_data":{
+        "category":[
+        {
+            "name":"Buddy List",
+            "subcategory":[
+            {
+                "name":"Buddy List",
+                "item":[
+                {
+                    "variable":"$enablebl",
+                    "default_value": 0,
+                    "description":"Buddy List:",
+                    "type":"radio",
+                    "data":[
+                    {
+                        "text":"Enabled",
+                        "value":"1"
+                    },
+                    {
+                        "text":"Disabled",
+                        "value":"0"
+                    }
+                    ]
+                },
+                {
+                    "variable":"$enableblsk",
+                    "default_value": 1,
+                    "description":"Buddy List Soft Keys:",
+                    "type":"radio",
+                    "data":[
+                    {
+                        "text":"Enabled",
+                        "value":"1"
+                    },
+                    {
+                        "text":"Disabled",
+                        "value":"0"
+                    }
+                    ]
+                },
+                {
+                	"type":"break"
+                },
+                {
+                    "description":"Buddy List Options",
+                    "type":"loop",
+                    "loop_start":"1",
+                    "loop_end":"32",
+                    "data":{
+                        "item":[
+                        {
+                            "variable":"$bl_fname",
+                            "default_value":"",
+                            "description":"Buddy List {$count} First Name",
+                            "type":"input"
+                        },
+                        {
+                            "variable":"$bl_lname",
+                            "default_value":"",
+                            "description":"Buddy List {$count} Last Name",
+                            "type":"input"
+                        },
+                        {
+                            "variable":"$bl_bext",
+                            "default_value":"",
+                            "description":"Extension",
+                            "type":"input"
+                        },
+                        {
+                            "variable":"$bl_type",
+                            "default_value":"",
+                            "description":"Type",
+                            "type":"list",
+                            "data":[
+                            {
+                                "text":"Speed Dial",
+                                "value":"0"
+                            },
+                            {
+                                "text":"BLF",
+                                "value":"1"
+                            }
+                            ]
+                        },
+                        {
+                            "type":"break"
+                        }
+                        ]
+                    }
+                }
+                ]
+            }
+            ]
+        }
+        ]
+    }
+}

--- a/endpoint/polycom/splm/family_data.json
+++ b/endpoint/polycom/splm/family_data.json
@@ -47,7 +47,8 @@
         "id": "6",
         "template_data": [
           "linekeys.json",
-          "template_data.json"
+          "template_data.json",
+          "buddylist.json"
         ]
       },
       {

--- a/endpoint/polycom/splm/phone.php
+++ b/endpoint/polycom/splm/phone.php
@@ -65,6 +65,21 @@ class endpoint_polycom_splm_phone extends endpoint_polycom_base {
 
         $this->settings['createdFiles'] = implode(', ', array_values($this->configfiles));
 
+        //This is for the old school buddylist file
+        if (isset($this->settings['enablebl']) && ($this->settings['enablebl'] == 1)) {
+            $result['contacts/' . $this->mac . '-directory.xml'] = 'contacts/$mac-directory.xml';
+            $this->settings['presence'] = 1;
+            foreach ($this->settings['loops']['bl'] as $key => $data) {
+                if (!empty($data['fname']) && !empty($data['bext'])) {
+                    $this->settings['loops']['bl'][$key]['type'] = isset($this->settings['loops']['bl'][$key]['type']) ? $this->settings['loops']['bl'][$key]['type'] : '0';
+                } else {
+                    unset($this->settings['loops']['bl'][$key]);
+                }
+            }
+        } else {
+            $this->settings['presence'] = 0;
+        }
+
         return $result;
     }
 


### PR DESCRIPTION
We're trying to make some modifications to support buddy lists on our polycom 601 phones. The main issue I'm running into is that no matter what we specify in the buddy list section when creating the template, the generated file in contacts/$mac-directory.xml is always blank. It generates the file, just with no data. Is there something else we need to modify?