### PR TITLE
Removed Duplicate "BLF Transfer" entry and added "Transfer"

### DIFF
--- a/endpoint/aastra/aap9xxx6xxx/prgkeys.json
+++ b/endpoint/aastra/aap9xxx6xxx/prgkeys.json
@@ -106,8 +106,8 @@
                           "value":"speeddialconf"
                         },
                         {
-                          "text":"BLF Transfer",
-                          "value":"blfxfer"
+                          "text":"Transfer",
+                          "value":"xfer"
                         },
                         {
                           "text":"Conference",


### PR DESCRIPTION
"BLF Transfer" was listed twice and regular "Transfer" was missing; renamed and changed value for second "BLF Transfer" entry to "Transfer" / "xfer"