### PR TITLE
protected_files must be an array

### DIFF
--- a/endpoint/snom/base.php
+++ b/endpoint/snom/base.php
@@ -10,7 +10,7 @@
 class endpoint_snom_base extends endpoint_base {
 
     public $brand_name = 'snom';
-    public $protected_files = 'general_custom.xml';
+    public $protected_files = array('general_custom.xml');
     public $mapfields=array(
 	'dateformat'=>array('middle-endian'=>'on','big-endian'=>'off','default'=>'off'),
     );

--- a/endpoint/thomson/base.php
+++ b/endpoint/thomson/base.php
@@ -10,7 +10,7 @@
 class endpoint_thomson_base extends endpoint_base {
 
     public $brand_name = 'thomson';
-    public $protected_files = 'general_custom.xml';
+    public $protected_files = array('general_custom.xml');
 
     function prepare_for_generateconfig() {
         parent::prepare_for_generateconfig();


### PR DESCRIPTION
$protected_files must be an array, or an error is thrown when rebuilding config:

in_array() expects parameter 2 to be array, string given (in admin/­modules/­endpointman/­includes/­functions.inc line 1289)