### PR TITLE
Fixed duplicated brand id

### DIFF
--- a/endpoint/patton/brand_data.json
+++ b/endpoint/patton/brand_data.json
@@ -2,7 +2,7 @@
   "data": {
     "brands": {
       "name": "Patton",
-      "brand_id": "19",
+      "brand_id": "20",
       "directory": "patton",
       "package": "patton.tgz",
       "md5sum": "",


### PR DESCRIPTION
Brand id of Patton and Intelbras were both 19 creating problems during update.

Changed Patton brand id to 20

Beppo