### PR TITLE
Cisco spa: Update template_data.json

### DIFF
--- a/endpoint/cisco/spa/template_data.json
+++ b/endpoint/cisco/spa/template_data.json
@@ -105,7 +105,7 @@
               },
               {
                 "variable":"$dial_plan",
-                "default_value":"( [23456789]11 | *xxx. | <:1352>[2-9]xxxxxx | <:1>[2-9]xx[2-9]xxxxxxS0 | 1[2-9]xx[2-9]xxxxxxS0 | 011xxxxxxx. | [#*x][*x][*x]. )",
+                "default_value":"( [23456789]11 | *xxx. | <:1>[2-9]xx[2-9]xxxxxxS0 | 1[2-9]xx[2-9]xxxxxxS0 | 011xxxxxxx. | [#*x][*x][*x]. )",
                 "description":"Dial Plan",
                 "type":"input"
               },


### PR DESCRIPTION
Remove "| <:1352>[2-9]xxxxxx" from default dial plan as this prefixes 1352 to all 7 digit numbers and strips the dialed area code from a 10 digit number then prefixes 1352 to the remaining 7 dialed digits before passing the number to the PBX or SIP provider.