### PR TITLE
UNIVERSAL Dial Plan

### DIFF
--- a/endpoint/cisco/spa5xx/template_data.json
+++ b/endpoint/cisco/spa5xx/template_data.json
@@ -154,7 +154,7 @@
               },
               {
                 "variable":"$dial_plan",
-                "default_value":"( [23456789]11 | *xxx. | <:1>[2-9]xx[2-9]xxxxxxS0 | 1[2-9]xx[2-9]xxxxxxS0 | 011xxxxxxx. | [#*x][*x][*x]. )",
+                "default_value":"( [23456789]11 | *xxx. | [2-9]xxxxxx | [2-9]xx[2-9]xxxxxxS0 | 1[2-9]xx[2-9]xxxxxxS0 | 011xxxxxxx. | [#*x][*x][*x]. )",
                 "description":"Dial Plan",
                 "type":"input"
               },


### PR DESCRIPTION
This change addresses @sonic331va concerns and also allows 7, 10, 11 digit dialing...
For 7 & 10 digit dialing, outbound rules need to be setup to:

Rule 1. Add 1 + "area code" for 7 digit numbers 
ie. Prepend=(1222) Prefix="Field Left Blank" MatchPattern=NXXXXXX

Rule 2. Add 1 for 10 digit numbers
ie. Prepend=(1) Prefix="Field Left Blank" MatchPattern=NXXNXXXXXX

Rule 3. Allow 11 digit dialing
ie. Prepend="Field Left Blank" Prefix="Field Left Blank" MatchPattern=1NXXNXXXXXX

Resulting behavior assuming appropriate outbound rules have been configured as above:
7 digit numbers - After dialing a 7 digit number AND the Cisco "Default Interdigit_Short_Timer" of 3 seconds expires, the 7 digits are sent from the phone. Then, outbound rule #1 adds a 1 + the area code configured in the rule to the 7 dialed digits.
ie. if rule #1 is set as above... When you dial 3334444 on the phone, it adds a 1 + 222 in front of 3334444 and the PBX sends 12223334444 to the trunk.

10 digit numbers - After dialing 10 digits, the 10 digits are sent immediately (S0) from the phone. Then, outbound rule #2 adds a 1 as configured in the rule to the 10 dialed digits.
ie. if rule #2 is set as above... When you dial 2223334444 on the phone, it adds a 1 in front of 2223334444 and the PBX sends 1222333444 to the trunk.

11 digit numbers - allowing 11 digit numbers to send immediately (S0) from the phone. Then, outbound rule #3 does not modify the 11 dialed digits.
ie. if rule #3 is set as above... When you dial 12223334444 on the phone, the PBX simply sends 12223334444 to the trunk.