### PR TITLE
Test on current supported php versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ php:
   - 5.2
   - 5.3
   - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+  - 7.2
 script: phpunit tests/phpunittests
 
 notifications:


### PR DESCRIPTION
http://php.net/supported-versions.php
Run tests on the supported versions of PHP which are as of right now, 5.6, 7.0, 7.1, 7.2.
Letting the tests run on the older unsupported versions of PHP (5.5 and older) for information purposes only.