### PR TITLE
Correct fix to support all 18 buttons on Snom 72X models

### DIFF
--- a/endpoint/snom/7xx/function_keys.json
+++ b/endpoint/snom/7xx/function_keys.json
@@ -47,10 +47,10 @@
                 "type":"break"
               },
               {
-                "description":"Function Keys (0-14)",
+                "description":"Function Keys (0-18)",
                 "type":"loop",
                 "loop_start":"0",
-                "loop_end":"14",
+                "loop_end":"18",
                 "data":{
                   "item":[
                     {

--- a/endpoint/snom/7xx/function_keys.json
+++ b/endpoint/snom/7xx/function_keys.json
@@ -47,10 +47,10 @@
                 "type":"break"
               },
               {
-                "description":"Function Keys (0-18)",
+                "description":"Function Keys (0-17)",
                 "type":"loop",
                 "loop_start":"0",
-                "loop_end":"18",
+                "loop_end":"17",
                 "data":{
                   "item":[
                     {


### PR DESCRIPTION
These phones have 18 buttons.  Originally file only allowed for 15 buttons.