### PR TITLE
update autoload.php

### DIFF
--- a/autoload.php
+++ b/autoload.php
@@ -27,8 +27,11 @@ class ProvisionerConfig {
 
         // Try to include the class
         $file = str_replace('_', DIRECTORY_SEPARATOR, $class) . '.php';
-        if (is_file(PROVISIONER_BASE . $file)) {
-            require_once(PROVISIONER_BASE . $file);
+
+		$file = FreePBX::Endpointman()->PHONE_MODULES_PATH . $file;
+
+        if (is_file($file)) {
+            require $file;
 
             return TRUE;
         }


### PR DESCRIPTION
This fixes an Ajax error when trying to edit the config files in the product configuration editor.  it occurs when selecting the phone models on the right side of the page.